### PR TITLE
Use non-minified code as entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-onboarding-component",
   "version": "0.0.5",
   "description": "React Native App Onboarding component for IOS & Android.",
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && babel src/ -d dist/"


### PR DESCRIPTION
The code should get minified during the production build anyways and using the non-minified code as the entry is better for IDE support.